### PR TITLE
Expand the label name rules: can now contain dashes (-) and start with numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Empty rules (<foo> ::= ;) and empty alternatives (<foo> ::= | "foo") are not all
 Example of a valid rule: <start> ::= <foo> | <bar> ;
 ```
 
+Label names can contain: a-z A-Z 0-9 _ -
+
+```
+# example label names
+<label-name>
+<LABEL_NAME>
+<42>
+<---dashes---are---cool--->
+<___underscores___are___cool___too___>
+```
+
 One problem with using straight BNF for driving language _generators_ is that you have no control
 over the process. BNFGen adds two features to fix that.
 

--- a/bnfgen.opam
+++ b/bnfgen.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "bnfgen"
-version: "3.0.0"
+version: "3.1.0"
 synopsis: "Random text generator that takes context-free grammars from BNF files"
 description: """
 BNFGen generates random texts based on user-defined context-free grammars

--- a/src/bnfgen_cli.ml
+++ b/src/bnfgen_cli.ml
@@ -23,7 +23,7 @@
 type cmd_action = Dump | Reduce
 
 let print_version () =
-  print_endline "bnfgen 3.0.0";
+  print_endline "bnfgen 3.1.0";
   print_endline "Copyright 2021, Daniil Baturin, MIT license";
   print_endline "https://baturin.org/tools/bnfgen"
 

--- a/src/lib/bnf_lexer.mll
+++ b/src/lib/bnf_lexer.mll
@@ -102,7 +102,7 @@ and read_identifier buf =
     parse
     | '>' { IDENTIFIER (Buffer.contents buf) }
     | '<' { lexing_error lexbuf "Unmatched left angle bracket" }
-    | ([ 'a' - 'z' 'A' - 'Z' '_'] [ 'a' - 'z' 'A' - 'Z' '0' - '9' '_' ]*)
+    | ([ 'a' - 'z' 'A' - 'Z' '0' - '9' '_' '-' ] [ 'a' - 'z' 'A' - 'Z' '0' - '9' '_' '-' ]*)
       { Buffer.add_string buf (Lexing.lexeme lexbuf); read_identifier buf lexbuf }
     | _ as bad_character
       {


### PR DESCRIPTION
Also update the README and push the version number

Note: An empty label (<>) is possible